### PR TITLE
deps: use native url over fast-url-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "homepage": "https://github.com/Brightspace/node-landlord-client",
   "dependencies": {
     "bluebird": "^3.5.0",
-    "fast-url-parser": "^1.1.3",
     "lru-cache": "^4.1.1",
     "parse-cache-control": "^1.0.1",
     "superagent": "^3.5.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var parseCacheControl = require('parse-cache-control'),
-	url = require('fast-url-parser'),
+	url = require('url'),
 	Promise = require('bluebird'),
 	request = require('superagent'),
 	tcpp = require('tcp-ping');


### PR DESCRIPTION
Native url module has seen many improvements since fast-url-parser was selected.

Fixes: https://github.com/Brightspace/node-landlord-client/issues/4