### PR TITLE
deps: use native Promise instead of bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   },
   "homepage": "https://github.com/Brightspace/node-landlord-client",
   "dependencies": {
-    "bluebird": "^3.5.0",
     "lru-cache": "^4.1.1",
     "parse-cache-control": "^1.0.1",
+    "promised-method": "^1.0.0",
     "superagent": "^3.5.2",
     "tcp-ping": "^0.1.1"
   },

--- a/src/abstract-cache.js
+++ b/src/abstract-cache.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var inherits = require('util').inherits,
-	Promise = require('bluebird');
+	promised = require('promised-method');
 
 function ValueLookupFailed(inner) {
 	this.name = 'ValueLookupFailed';
@@ -10,9 +10,11 @@ function ValueLookupFailed(inner) {
 }
 inherits(ValueLookupFailed, Error);
 
+function noop() {}
+
 function AbstractLandlordCache() {}
 
-AbstractLandlordCache.prototype.getTenantIdLookup = Promise.method(/* @this */ function getTenantIdLookup(host) {
+AbstractLandlordCache.prototype.getTenantIdLookup = promised(/* @this */ function getTenantIdLookup(host) {
 	if ('string' !== typeof host) {
 		throw new Error('"host" must be a String');
 	}
@@ -38,7 +40,7 @@ AbstractLandlordCache.prototype.getTenantIdLookup = Promise.method(/* @this */ f
 		});
 });
 
-AbstractLandlordCache.prototype.cacheTenantIdLookup = Promise.method(/* @this */ function cacheTenantIdLookup(host, tenantId) {
+AbstractLandlordCache.prototype.cacheTenantIdLookup = promised(/* @this */ function cacheTenantIdLookup(host, tenantId) {
 	if ('string' !== typeof host) {
 		throw new Error('"host" must be a String');
 	}
@@ -55,14 +57,14 @@ AbstractLandlordCache.prototype.cacheTenantIdLookup = Promise.method(/* @this */
 
 	return Promise
 		.resolve(this._set(key, tenantId, Infinity))
-		.return(undefined);
+		.then(noop);
 });
 
 AbstractLandlordCache.prototype._buildTenantIdLookupKey = function buildTenantIdLookupKey(host) {
 	return 'host-tid|' + host;
 };
 
-AbstractLandlordCache.prototype.getTenantUrlLookup = Promise.method(/* @this */ function getTenantUrlLookup(tenantId) {
+AbstractLandlordCache.prototype.getTenantUrlLookup = promised(/* @this */ function getTenantUrlLookup(tenantId) {
 	if ('string' !== typeof tenantId) {
 		throw new Error('"tenantId" must be a UUID');
 	}
@@ -88,7 +90,7 @@ AbstractLandlordCache.prototype.getTenantUrlLookup = Promise.method(/* @this */ 
 		});
 });
 
-AbstractLandlordCache.prototype.cacheTenantUrlLookup = Promise.method(/* @this */ function cacheTenantUrlLookup(tenantId, url, maxAge) {
+AbstractLandlordCache.prototype.cacheTenantUrlLookup = promised(/* @this */ function cacheTenantUrlLookup(tenantId, url, maxAge) {
 	if ('string' !== typeof tenantId) {
 		throw new Error('"tenantId" must be a UUID');
 	}
@@ -109,7 +111,7 @@ AbstractLandlordCache.prototype.cacheTenantUrlLookup = Promise.method(/* @this *
 
 	return Promise
 		.resolve(this._set(key, url, maxAge))
-		.return(undefined);
+		.then(noop);
 });
 
 AbstractLandlordCache.prototype._buildTenantUrlLookupKey = function buildTenantUrlLookupKey(tenantId) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var parseCacheControl = require('parse-cache-control'),
+	promised = require('promised-method'),
 	url = require('url'),
-	Promise = require('bluebird'),
 	request = require('superagent'),
 	tcpp = require('tcp-ping');
 
@@ -29,7 +29,7 @@ function LandlordClient(opts) {
 	this._landlordOpts = url.parse(this._landlord);
 }
 
-LandlordClient.prototype.lookupTenantId = Promise.method(/* @this */ function lookupTenantId(host) {
+LandlordClient.prototype.lookupTenantId = promised(/* @this */ function lookupTenantId(host) {
 	var self = this;
 
 	if ('string' !== typeof host || 0 === host.length) {
@@ -77,7 +77,7 @@ LandlordClient.prototype.lookupTenantId = Promise.method(/* @this */ function lo
 							._cache
 							.cacheTenantIdLookup(host, tenantId)
 							.catch(function() {})
-							.return(tenantId);
+							.then(function() { return tenantId; });
 
 						resolve(result);
 					});
@@ -150,7 +150,7 @@ LandlordClient.prototype.lookupTenantUrl = function lookupTenantUri(tenantId) {
 							._cache
 							.cacheTenantUrlLookup(tenantId, url, tenantInfo._maxAge)
 							.catch(function() {})
-							.return(url);
+							.then(function() { return url; });
 					}
 
 					return url;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Promise = require('bluebird');
 const __sinon__ = require('sinon');
 const expect = require('chai').expect;
 const nock = require('nock');


### PR DESCRIPTION
Just extracted _promised-method_ from node-auth-validation (https://github.com/Brightspace/node-auth-validation/blob/master/src/promised.js).

There exists a similar package, but wasn't a fan of the implementation, even though it's all trivial.

